### PR TITLE
fix for crash when generating thumbnail for NULL image

### DIFF
--- a/sorl_thumbnail_serializer/fields.py
+++ b/sorl_thumbnail_serializer/fields.py
@@ -77,6 +77,9 @@ class HyperlinkedSorlImageField(serializers.ImageField):
         Returns:
             a url pointing at a scaled and cached image
         """
+        if not value:
+            return None
+
         image = get_thumbnail(value, self.geometry_string, **self.options)
 
         try:


### PR DESCRIPTION
```
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line 149, in get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line 147, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/viewsets.py", line 87, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/views.py", line 466, in dispatch
    response = self.handle_exception(exc)
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/views.py", line 463, in dispatch
    response = handler(request, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/mixins.py", line 45, in list
    return self.get_paginated_response(serializer.data)
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/serializers.py", line 674, in data
    ret = super(ListSerializer, self).data
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/serializers.py", line 239, in data
    self._data = self.to_representation(self.instance)
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/serializers.py", line 614, in to_representation
    self.child.to_representation(item) for item in iterable
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/serializers.py", line 472, in to_representation
    ret[field.field_name] = field.to_representation(attribute)
  File "/usr/local/lib/python2.7/dist-packages/sorl_thumbnail_serializer/fields.py", line 90, in to_representation
    return super(HyperlinkedSorlImageField, self).to_native(image.url)  # NOQA
AttributeError: 'super' object has no attribute 'to_native'
```

avoiding this for None value
